### PR TITLE
ST-10280 【投稿v3/リポスト】go-twitterライブラリのRetweetレスポンス型にidを追加

### DIFF
--- a/v2/client_retweet_test.go
+++ b/v2/client_retweet_test.go
@@ -41,7 +41,9 @@ func TestClient_UserRetweet(t *testing.T) {
 					}
 					body := `{
 						"data": {
-						  "retweeted": true
+						  "retweeted": true,
+					      "id": "repost-1234",
+						  "rest_id": "repost-1234"
 						}
 					  }`
 					return &http.Response{
@@ -64,6 +66,8 @@ func TestClient_UserRetweet(t *testing.T) {
 			want: &UserRetweetResponse{
 				Data: &RetweetData{
 					Retweeted: true,
+					ID:        "repost-1234",
+					RestID:    "repost-1234",
 				},
 				RateLimit: &RateLimit{
 					Limit:     15,
@@ -163,7 +167,7 @@ func TestClient_DeleteUserRetweet(t *testing.T) {
 				tweetID: "tweet-1234",
 			},
 			want: &DeleteUserRetweetResponse{
-				Data: &RetweetData{
+				Data: &DeleteRetweetData{
 					Retweeted: false,
 				},
 				RateLimit: &RateLimit{

--- a/v2/user_retweet.go
+++ b/v2/user_retweet.go
@@ -6,8 +6,17 @@ import (
 	"strings"
 )
 
-// RetweetData will be returned by the manage retweet APIs
+// RetweetData will be returned by the create retweet API
+// Warning: Documentation lists the repost ID field name as "id" but as of 2025-04-01 it's actually "rest_id" so both should be checked.
+// @see https://docs.x.com/x-api/posts/causes-the-user-in-the-path-to-repost-the-specified-post#response-data
 type RetweetData struct {
+	Retweeted bool   `json:"retweeted"`
+	ID        string `json:"id"`
+	RestID    string `json:"rest_id"`
+}
+
+// RetweetData will be returned by the delete retweet API
+type DeleteRetweetData struct {
 	Retweeted bool `json:"retweeted"`
 }
 
@@ -19,7 +28,7 @@ type UserRetweetResponse struct {
 
 // DeleteUserRetweetResponse is the response with a user retweet
 type DeleteUserRetweetResponse struct {
-	Data      *RetweetData `json:"data"`
+	Data      *DeleteRetweetData `json:"data"`
 	RateLimit *RateLimit
 }
 

--- a/v2/user_retweet.go
+++ b/v2/user_retweet.go
@@ -15,7 +15,7 @@ type RetweetData struct {
 	RestID    string `json:"rest_id"`
 }
 
-// RetweetData will be returned by the delete retweet API
+// DeleteRetweetData will be returned by the delete retweet API
 type DeleteRetweetData struct {
 	Retweeted bool `json:"retweeted"`
 }


### PR DESCRIPTION
## 変更内容
- X API v2のリポスト作成APIは以前IDを返していなかったが現在は作成したリポストのIDを返しているようです
![image](https://github.com/user-attachments/assets/8d86d439-e981-48f1-9b43-8209524b94fc)

- 使っているgoライブラリ go-twitter のレスポンス構造体にIDは存在しないので取得できない
https://github.com/g8rswimmer/go-twitter/blob/cec1b956cc1113a84c20d4a5f5e02b4d5534c0af/v2/user_retweet.go#L9-L12

- 対象のフィールドを構造体に追加しました
  - ドキュメンテーションには `id` というフィールドに入ると書いてあるが実際は `rest_id` という名前になっているので両方を追加しました（今後idに修正されそうなので利用する時は `id = res.id == "" ? res.rest_id : res.id` という感じになりそうです）
    - https://docs.x.com/x-api/posts/causes-the-user-in-the-path-to-repost-the-specified-post#response-data
 
## 影響範囲・懸念点
- Goでリポスト機能はまだ利用していないので影響はない想定です
（後はgo.modのコミットハッシュを更新しなければ更新されないと思います）
https://github.com/socialdog-inc/socialdog/blob/5165e5cfd58457a3ffca5d4955973439fb952c09/web/application_go/go.mod#L148

## 確認してほしいこと
- 修正内容は問題なさそうか


＊ CIはないですがローカルでテストを実行しました
![image](https://github.com/user-attachments/assets/42529ce6-0720-47ea-bee5-47232362423f)
