### PR TITLE
ST-12486 go-twitter-v2のCreateTweetにて、リプライでない投稿にPollがあるとpanicを起こす問題を修正する

### DIFF
--- a/v2/tweet_manage.go
+++ b/v2/tweet_manage.go
@@ -26,7 +26,7 @@ func (t CreateTweetRequest) validate() error {
 			return fmt.Errorf("create tweet error: %w", err)
 		}
 	}
-	if t.Poll != nil {
+	if t.Reply != nil {
 		if err := t.Reply.validate(); err != nil {
 			return fmt.Errorf("create tweet error: %w", err)
 		}

--- a/v2/tweet_manage_test.go
+++ b/v2/tweet_manage_test.go
@@ -142,10 +142,10 @@ func TestCreateTweetOps_validate(t *testing.T) {
 		QuoteTweetID          string
 		Text                  string
 		ReplySettings         string
-		Geo                   CreateTweetGeo
-		Media                 CreateTweetMedia
-		Poll                  CreateTweetPoll
-		Reply                 CreateTweetReply
+		Geo                   *CreateTweetGeo
+		Media                 *CreateTweetMedia
+		Poll                  *CreateTweetPoll
+		Reply                 *CreateTweetReply
 	}
 	tests := []struct {
 		name    string
@@ -156,7 +156,7 @@ func TestCreateTweetOps_validate(t *testing.T) {
 			name: "valid",
 			fields: fields{
 				Text: "Hello World",
-				Media: CreateTweetMedia{
+				Media: &CreateTweetMedia{
 					IDs: []string{"12345"},
 				},
 			},
@@ -165,7 +165,7 @@ func TestCreateTweetOps_validate(t *testing.T) {
 		{
 			name: "valid2",
 			fields: fields{
-				Media: CreateTweetMedia{
+				Media: &CreateTweetMedia{
 					IDs: []string{"12345"},
 				},
 			},
@@ -175,6 +175,17 @@ func TestCreateTweetOps_validate(t *testing.T) {
 			name: "valid3",
 			fields: fields{
 				Text: "Hello World",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid4",
+			fields: fields{
+				Text: "Hello World",
+				Poll: &CreateTweetPoll{
+					DurationMinutes: 60,
+					Options:         []string{"yes", "no"},
+				},
 			},
 			wantErr: false,
 		},
@@ -192,10 +203,10 @@ func TestCreateTweetOps_validate(t *testing.T) {
 				QuoteTweetID:          tt.fields.QuoteTweetID,
 				Text:                  tt.fields.Text,
 				ReplySettings:         tt.fields.ReplySettings,
-				Geo:                   &tt.fields.Geo,
-				Media:                 &tt.fields.Media,
-				Poll:                  &tt.fields.Poll,
-				Reply:                 &tt.fields.Reply,
+				Geo:                   tt.fields.Geo,
+				Media:                 tt.fields.Media,
+				Poll:                  tt.fields.Poll,
+				Reply:                 tt.fields.Reply,
 			}
 			if err := opts.validate(); (err != nil) != tt.wantErr {
 				t.Errorf("CreateTweetOps.validate() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
## 変更内容

- nilチェックするフィールドが誤っており、以下の条件の場合に`t.Reply.validate()`でpanicが発生する問題を修正しました。
  - `t.Poll`が指定されている
  - `t.Reply`がnil
- Pollのテストを追加しました。


## 確認して欲しいこと
- 実装に問題がないこと

ローカルでテストが通ることは確認しています。


